### PR TITLE
fix player-O-highlighting during turn. Cause: inconsistent symbol use between 'O' and '0' in app.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,8 +38,8 @@ function App() {
           />
           <Player
             initialName="Player 2"
-            symbol="0"
-            isActive={activePlayer === "0"}
+            symbol="O"
+            isActive={activePlayer === "O"}
           />
         </ol>
         <GameBoard onSelectSquare={handleSelectedSquare} turns={gameTurns} />


### PR DESCRIPTION
Fixed mixup of symbols 'O' and '0' in app.jsx causing player O not to highlight during their turn.